### PR TITLE
Update to compile localtime_r in Windows

### DIFF
--- a/header.h
+++ b/header.h
@@ -10,8 +10,10 @@
 #include <io.h>
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#define localtime_r(X,Y) (localtime_s(Y,X))
 #else
 #include <unistd.h>
+#include <sys/time.h>
 #define O_BINARY 0
 #endif
 
@@ -38,7 +40,7 @@ typedef unsigned int   dword;
 typedef struct {
   char  name[32];
   char  module[32];
-  byte  commonVar;;
+  byte  commonVar;
   char  common[32];
   word  offset;
   byte  type;
@@ -349,4 +351,3 @@ extern int  getDefine(char* define);
 extern void writeOutput();
 
 #endif
-

--- a/startup.c
+++ b/startup.c
@@ -9,7 +9,6 @@
 */
 
 #include "header.h"
-#include <sys/time.h>
 #include <time.h>
 
 // R7 - data stack
@@ -206,4 +205,3 @@ void startup() {
   showCompiler = ctmp;
   if (passNumber == 1) runtime = address;
   }
-


### PR DESCRIPTION
Moved #include <sys/time> from startup.c into Non-Windows conditional block in header.h for Linux.  Added macro definition for localtime_r() to Windows conditional block in header.h to compile correctly under Windows.